### PR TITLE
Add hasAttr

### DIFF
--- a/lib/easy-test.js
+++ b/lib/easy-test.js
@@ -218,6 +218,40 @@
    * @memberof EasyTest
    * @description
    *
+   * Tests an HTMLElement or Angular/jQuery element to see if it contains
+   * some attribute, optionally with some given value.
+   *
+   * @param {HTMLElement|angular.element} element the element to be tested.
+   * @param {string} attr the name of the attribute being tested.
+   * @param {string} val optional: the value of the attribute being tested.
+   *
+   * @returns {boolean} Whether the element contains the attribute `attr`.
+   * If `val` is provided, returns true if and only if the value of `attr` is
+   * also `val`.
+   *
+   * @example
+   * var element = EasyTest.compileDirective('&lt;p foo="bar"&gt;&lt;/p&gt;');
+   * expect(EasyTest.hasAttr(element[0], 'foo')).to.be.true;
+   * expect(EasyTest.hasAttr(element[0], 'foo', 'bar')).to.be.true;
+   */
+  EasyTest.hasAttr = function hasAttr(element, attr, val) {
+    element = angular.element.prototype.isPrototypeOf(element) ? 
+      element[0] : element;
+
+    var attrs = element.attributes;
+    for (var k in attrs) {
+      var objAttr = attrs[k];
+      if ((objAttr.name === attr) && (typeof val === 'undefined' || objAttr.value === val)) {
+        return true;
+      }
+    }
+    return false;
+  };
+
+  /**
+   * @memberof EasyTest
+   * @description
+   *
    * Tests an object against a JSON specification object.
    *
    * @param {object} object The object to test.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-easy-test",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Framework for making Angular Unit Test's easier to write.",
   "main": "lib/easy-test.js",
   "repository": {

--- a/test/tests.js
+++ b/test/tests.js
@@ -238,6 +238,33 @@ describe('angular-easy-test', function() {
 
   });
 
+  describe('#hasAttr', function() {
+    it('should check element for attribute exists', function() {
+      var element = EasyTest.compileDirective('<div foo></div>');
+      expect(EasyTest.hasAttr(element[0], 'foo')).to.equal(true);
+    });
+
+    it('should check element for attribute not exist', function() {
+      var element = EasyTest.compileDirective('<div></div>');
+      expect(EasyTest.hasAttr(element[0], 'foo')).to.equal(false);
+    });
+
+    it('should check element for attribute value', function() {
+      var element = EasyTest.compileDirective('<div pi="3.14159"></div>');
+      expect(EasyTest.hasAttr(element[0], 'pi', '3.14159')).to.equal(true);
+    });
+
+    it('should check element for attribute value not equal', function() {
+      var element = EasyTest.compileDirective('<div pi="3.14159"></div>');
+      expect(EasyTest.hasAttr(element[0], 'pi', '2.71828')).to.equal(false);
+    });
+
+    it('should work with Angular/jQuery element', function() {
+      var element = EasyTest.compileDirective('<div thing="stuff"></div>');
+      expect(EasyTest.hasAttr(element, 'thing', 'stuff')).to.equal(true);
+    });
+  });
+
   describe('#getService', function() {
 
     it('should return a service correctly', function() {


### PR DESCRIPTION
Adds a function, `hasAttr`, which allows testing attribute existence and values on the root element of either an `HTMLElement` or jQuery/Angular element.