### PR TITLE
Extend mockModule to be able to mock providers, services, constants, and values.

### DIFF
--- a/lib/easy-test.js
+++ b/lib/easy-test.js
@@ -45,28 +45,63 @@
    * Optionally registers a number of services with the mocked module.
    *
    * @param {string} moduleName The name of the module to mock.
-   * @param {array} services An array of objects representing fake services to register
-   * with the module. Each object must have a name property representing the
-   * name of the service and a provider property which is the body of the
-   * service, i.e. an object that has the functions and properties of the service.
+   * @param {array | object} services An array of objects representing fake 
+   * services to register with the module. Each object must have a `name` property
+   * representing the name of the service, and then one of `provider`, `constant`,
+   * `value`, `factory`, or `service`. Alternately, you can supply an object matching
+   * names to factories.
    *
    * @example
    * // Mock MyModule and provide the passed fake services to it.
    * EasyTest.mockModule('MyModule', [{
-   *   name: 'MyFakeServiceName', =
-   *   provider: {
+   *   name: 'MyFakeServiceName',
+   *   factory: {
    *     get: function() {},
    *     name: 'ServiceName'
    *   }
+   * }, 
+   * {
+   *   name: 'MyFakeConstant',
+   *   constant: 1337
    * }]);
+   *
+   * @example
+   * // Mock MyModule and provide the passed fake services to it.
+   * EasyTest.mockModule('MyOtherModule', {
+   *   FooFactory: { foo: function() {} },
+   *   BarFactory: { bar: function() {} }
+   * });
    */
   EasyTest.mockModule = function mockModule(moduleName, services) {
     services = services || [];
+
+    // if services is just a hash, convert to an array of all factories
+    services = Array.isArray(services) ? services :
+      Object.keys(services).map(function(name) {
+        return {
+          name: name,
+          factory: services[name]
+        };
+      });
+
+    // iterate over each service, mocking it by type
+    var mockTypes = [ 'factory', 'service', 'provider', 'value', 'constant' ];
     angular.mock.module(moduleName, function($provide) {
-      services.forEach(function (service) {
-        $provide.factory(service.name, [ function () {
-          return service.provider;
-        }]);
+      services.forEach(function serviceProvide(service) {
+        mockTypes.forEach(function mockIfExists(mocktype) {
+          if (service[mocktype]) {
+            if (mocktype === 'factory' || mocktype === 'service') {
+              // if mocktype is factory or service, mock it into $getFn
+              $provide[mocktype](service.name, [ function() {
+                return service[mocktype];
+              }]);
+            }
+            else {
+              // else, mock normally (?)
+              $provide[mocktype](service.name, service[mocktype]);
+            }
+          }
+        });
       });
     });
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-easy-test",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "Framework for making Angular Unit Test's easier to write.",
   "main": "lib/easy-test.js",
   "repository": {

--- a/test/app.js
+++ b/test/app.js
@@ -44,3 +44,17 @@ simpleapp3.factory('TestService3', function() {
     anotherPropHere: 1
   };
 });
+
+var simpleapp4 = angular.module('simpleapp4', [])
+  .controller('simpleCtrl', function($scope, $baz) {
+    $scope.baz = function baz() {
+      return $baz;
+    };
+  })
+  .provider({
+    $baz: function somethingStupidThatShouldBeMocked() {
+      this.$get = function $get() {
+        return 'arbitrary result that should be mocked';
+      };
+    }
+  });

--- a/test/tests.js
+++ b/test/tests.js
@@ -30,16 +30,80 @@ describe('angular-easy-test', function() {
       inject(function(TestService1) {});
     });
 
-    it('should be able to provide fake services', function() {
+    it('should be able to mock provider', function() {
+      EasyTest.mockModule('simpleapp4', [{
+        name: '$baz',
+        provider: function() {
+          this.$get = function $get() {
+            return 4;
+          };
+        }
+      }]);
+
+      inject(function($controller, $rootScope, $baz) {
+        var scope = $rootScope.$new();
+        $controller('simpleCtrl', {
+          $scope: scope,
+          $baz: $baz
+        });
+        expect(scope.baz()).to.equal(4);
+      });
+    });
+
+    it('should be able to mock constant', function() {
+      EasyTest.mockModule('simpleapp', [{
+        name: 'foo',
+        constant: [666, 1337]
+      }]);
+      inject(function(foo) {
+        expect(foo).to.deep.equal([666, 1337]);
+      });
+    });
+
+    it('should be able to mock value', function() {
+      EasyTest.mockModule('simpleapp', [{
+        name: 'bar',
+        value: 5
+      }]);
+      inject(function(bar) {
+        expect(bar).to.equal(5);
+      });
+    });
+
+    it('should be able to mock factory', function() {
+      EasyTest.mockModule('simpleapp', [{
+        name: 'FakeFactory',
+        factory: {
+          testFunction: function() {}
+        }
+      }]);
+      inject(function(FakeFactory) {
+        expect(FakeFactory).to.respondTo('testFunction');
+      });
+    });
+
+    it('should be able to mock factory as hash', function() {
+      EasyTest.mockModule('simpleapp', {
+        'FakeFactory': {
+          testFunction: function() {}
+        }
+      });
+      inject(function(FakeFactory) {
+        expect(FakeFactory).to.respondTo('testFunction');
+      });
+    });
+
+    it('should be able to mock service', function() {
       EasyTest.mockModule('simpleapp', [{
         name: 'FakeService',
-        provider: { testFunction: function() {} }
+        service: {
+          testFunction: function() {} 
+        }
       }]);
       inject(function(FakeService) {
         expect(FakeService).to.respondTo('testFunction');
       });
     });
-
   });
 
   describe('#mockModules', function() {
@@ -65,7 +129,7 @@ describe('angular-easy-test', function() {
         name: 'simpleapp3',
         values: [{
           name: 'TestService3',
-          provider: {
+          factory: {
             fakePropHere: 1
           }
         }]


### PR DESCRIPTION
Extended `mockModule` to be able to make use of more functionalities in the `$provide` API, namely the ability to mock things other than factories, i.e. providers, services, constants, and values.

I've upped the version to 2.0.0. This PR *breaks things*. Namely, if you've been doing something like `EasyTest.mockModule('foo', [{ name: 'baz', provider: something }])`, this will mock `something` as a provider, not a factory.

This should close [#1](https://github.com/EventMobi/angular-easy-test/issues/1).