### PR TITLE
Attach directives to elements during compilation.

### DIFF
--- a/lib/easy-test.js
+++ b/lib/easy-test.js
@@ -257,6 +257,7 @@
    *
    * @param {string} directiveHTML The HTML of the directive to be compiled.
    * @param {object} scope a dictionary of variables that will be inserted into the element's scope.
+   * @param {HTMLElement|angular.element} parent an element to attach the compiled directive as a child to.
    *
    * @returns {HTMLElement} The top level HTML element of the compiled directive.
    *
@@ -269,7 +270,15 @@
    * var element = EasyTest.compileDirective('&lt;p&gt;{{a}} {{b}}&lt;/p&gt;', scope);
    * expect(element.text()).to.equal('1 something');
    */
-  EasyTest.compileDirective = function compileDirective(directiveHTML, scope) {
+  EasyTest.compileDirective = function compileDirective(directiveHTML, scope, parent) {
+    // if scope is a Node or angular.element, set parent to scope 
+    //  and ignore parent
+    if (Node.prototype.isPrototypeOf(scope) || 
+        angular.element.prototype.isPrototypeOf(scope)) {
+      parent = scope;
+      scope = null;
+    }
+
     var $el;
     inject(function($compile, $rootScope) {
       var $scope = $rootScope.$new();
@@ -277,6 +286,14 @@
         angular.extend($scope, scope);
       }
       $el = angular.element(directiveHTML);
+
+      if (parent) {
+        // since angular.element(foo) doesn't do anything if foo is
+        //  already an angular.element, we can simply call it anyways
+        parent = angular.element(parent);
+        parent.append($el);
+      }
+
       $compile($el)($scope);
       $scope.$digest();
     });

--- a/lib/easy-test.js
+++ b/lib/easy-test.js
@@ -257,7 +257,8 @@
    *
    * @param {string} directiveHTML The HTML of the directive to be compiled.
    * @param {object} scope a dictionary of variables that will be inserted into the element's scope.
-   * @param {HTMLElement|angular.element} parent an element to attach the compiled directive as a child to.
+   * @param {HTMLElement|angular.element} parent an element to attach the compiled directive as a child.
+   *  If <code>scope</code> is an HTMLElement or an Angular element, it will be treated as the parent.
    *
    * @returns {HTMLElement} The top level HTML element of the compiled directive.
    *
@@ -269,6 +270,17 @@
    * var scope = { a: 1, b: 'something' };
    * var element = EasyTest.compileDirective('&lt;p&gt;{{a}} {{b}}&lt;/p&gt;', scope);
    * expect(element.text()).to.equal('1 something');
+   *
+   * @example
+   * var scope = { foo: 'bar' };
+   * var parent = angular.element('&lt;div&gt;baz&lt;/div&gt;');
+   * var element = EasyTest.compileDirective('&lt;p&gt;{{foo}}&lt;/p&gt;', scope, parent);
+   * expect(angular.element(parent.children()[0]).text()).to.equal('bar');
+   *
+   * @example
+   * var parent = angular.element('&lt;div&gt;baz&lt;/div&gt;');
+   * var element = EasyTest.compileDirective('&lt;p&gt;baz&lt;/p&gt;', parent);
+   * expect(angular.element(parent.children()[0]).text()).to.equal('baz');
    */
   EasyTest.compileDirective = function compileDirective(directiveHTML, scope, parent) {
     // if scope is a Node or angular.element, set parent to scope 

--- a/test/tests.js
+++ b/test/tests.js
@@ -300,6 +300,19 @@ describe('angular-easy-test', function() {
       expect(element.text()).to.equal('6');
     });
 
+    it('should attach compiled directive to another element', function() {
+      var parent = angular.element('<div></div>');
+      var element = EasyTest.compileDirective('<b>{{something}}</b>', {
+        something: 6
+      }, parent);
+      expect(parent.children()[0].textContent).to.equal('6');
+    });
+
+    it('should attach compiled directive to another element without scope provided', function() {
+      var parent = angular.element('<div></div>');
+      var element = EasyTest.compileDirective('<b test-directive></b>', parent);
+      expect(parent.children()[0].textContent).to.equal('Testa');
+    });
   });
 
   describe('#hasAttr', function() {


### PR DESCRIPTION
A pattern that I've noticed while writing tests is that since a lot of the Angular directives directly use `document`, I have to attach the directive to `document.body` before doing any sort of meaningful testing with it. This also means that I can't use `compileDirective` to compile the directive, since the compilation itself depends on the element being attached to the DOM.

I didn't have time to do this before, but I'd like to at least make it easier to test in the future. This basically lets you call `compileDirective` with a `parent` (either an `HTMLElement` or an Angular element), and the compiled directive will be attached to the `parent` as a child. Alternately, it detects if `scope` is an `HTMLElement` or an Angular element, and sets `parent` to it instead.