### PR TITLE
Add chai and mocha as devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "angular": "1.3.5",
     "angular-mocks": "1.3.5",
+    "chai": "3.0.0",
     "grunt": "0.4.5",
     "grunt-bump": "0.0.16",
     "grunt-contrib-jshint": "0.10.0",
@@ -31,7 +32,8 @@
     "karma-coverage": "0.2.7",
     "karma-mocha": "0.1.9",
     "karma-threshold-reporter": "0.1.12",
-    "matchdep": "0.3.0"
+    "matchdep": "0.3.0",
+    "mocha": "2.2.5"
   },
   "scripts": {
     "test": "grunt"


### PR DESCRIPTION
Resolves warning:

    npm WARN peerDependencies The peer dependency chai@* included from karma-chai will no
    npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency
    npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.
    npm WARN peerDependencies The peer dependency mocha@* included from karma-mocha will no
    npm WARN peerDependencies longer be automatically installed to fulfill the peerDependency
    npm WARN peerDependencies in npm 3+. Your application will need to depend on it explicitly.